### PR TITLE
Add self-check to contact_weight method

### DIFF
--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -126,6 +126,9 @@ class Actor:
         Returns:
             A weight of the contact between the two actors.
         """
+        if actor is self:
+            raise ValueError("actor must be a different instance than self")
+        
         weight = 0
         for location in self.shared_locations(actor=actor, location_labels=location_labels):
             weight += location.project_weights(actor1=self, actor2=actor)

--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -128,7 +128,7 @@ class Actor:
         """
         if actor is self:
             raise ValueError("actor must be a different instance than self")
-        
+
         weight = 0
         for location in self.shared_locations(actor=actor, location_labels=location_labels):
             weight += location.project_weights(actor1=self, actor2=actor)


### PR DESCRIPTION
Raises a ValueError if the provided actor is the same instance as self in the contact_weight method, preventing invalid comparisons.