### PR TITLE
extend notes to developers secton

### DIFF
--- a/docs/api/environment.rst
+++ b/docs/api/environment.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: pop2net.environment
 
 Environment
-=====
+===========
 
 .. autoclass:: pop2net.Environment
     :members:

--- a/docs/api/location_designer.rst
+++ b/docs/api/location_designer.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: pop2net
 
 LocationDesigner
-=============
+================
 
 The LocationDesigner class is an interface to design specific network structures using the Creator.
 

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -54,7 +54,12 @@ Every code contribution should include tests to help maintain quality and reliab
 We use pytest for testing and ship pytest as a dev dependency.
 That after installation, the tests can be run with ``poetry run pytest``
 
-4. Submitting a Pull Request
+4. Documenting changes
+----------------------
+
+If your contribution changes the behavior of pop2net in any way or adds features, please make sure all changes and functionalities are reflected in the documentation.
+
+5. Submitting a Pull Request
 ----------------------------
 
 - Push your branch to your fork.

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -5,23 +5,6 @@
 Notes to Developers
 ===================
 
-These are notes to developers.
-
-Installation
-============
-
-To install pop2net for development, it is strongly advised to use `poetry <https://python-poetry.org/>`_.
-This has to be installed outside the virtual environment.
-The recommended way to have poetry installed, generally is via `pipx <https://pipx.pypa.io/stable/installation/>`_.
-Once poetry is installed, just run ``poetry install`` from within the repository to install the package, all dependencies as well as all test and development dependencies.
-
-
-Testing
-=======
-
-We use pytest for testing and ship pytest as a dev dependency.
-That after installation, the tests can be run with ``poetry run pytest``
-
 Versioning
 ==========
 
@@ -31,27 +14,73 @@ We use a semantic versioning approach of MAJOR.MINOR.PATCH.
 - MINOR versions indicate the addition of new functionality, and
 - PATCH versions only fix bugs and do not otherwise influence the functionality of the package.
 
+.. note::
+  It is important to note, that all releases will be published on GitHub, but only stable releases (i.e., not prereleases -> there is no letter in the version number) will be released on pypi.
+  That ensures that users of the package can rely on PyPi to always have a up-to-date stable version, whereas developers can easily get pre-releases to test new functionality.
+
+
+How to Contribute
+=================
+
+Thank you for your interest in contributing! 🎉
+We welcome bug reports, feature requests, documentation improvements, and code contributions.
+
+1. Reporting Issues
+-------------------
+
+Use the `GitHub issues`_ to report bugs or suggest features.
+
+.. _GitHub issues: https://github.com/mariuzka/pop2net/issues
+
+When reporting a bug, include:
+
+- Steps to reproduce
+- Expected behavior
+- Actual behavior
+- Environment details (OS, Python version, package version)
+
+2. Development setup
+--------------------
+
+To install pop2net for development, it is strongly advised to use `poetry <https://python-poetry.org/>`_.
+This has to be installed outside the virtual environment.
+The recommended way to have poetry installed, generally is via `pipx <https://pipx.pypa.io/stable/installation/>`_.
+Once poetry is installed, just run ``poetry install`` from within the repository to install the package, all dependencies as well as all test and development dependencies.
+
+3. Testing
+----------
+
+Every code contribution should include tests to help maintain quality and reliability.
+We use pytest for testing and ship pytest as a dev dependency.
+That after installation, the tests can be run with ``poetry run pytest``
+
+4. Submitting a Pull Request
+----------------------------
+
+- Push your branch to your fork.
+- Open a Pull Request (PR) against the ``dev`` branch.
+- Clearly describe what your PR does and reference any related issues.
+- A maintainer will review your PR and may request changes.
+
+For core developers
+===================
 
 Branches
-========
+--------
 
 The ``main`` branch is locked and can only be modified via PRs.
 The general idea for a development workflow is:
 
 1. Create a new feature branch based on ``dev``.
 2. Create a PR from your feature branch to ``dev``.
-3. Once we release a new version, we set it up in ``dev`` and create a relase PR from ``dev`` to ``main``.
+3. Once we release a new version, we set it up in ``dev`` and create a release PR from ``dev`` to ``main``.
 
-If your are not a member of the core development team, PRs are generally always welcome. Please fork the repository, create a new branch and create your PRs from there to ``pop2net/dev``.
-
+If your are not a member of the core development team, PRs are generally always welcome.
+Please fork the repository, create a new branch and create your PRs from there to ``pop2net/dev``.
 
 How to Release
-==============
+--------------
 
 The release process is triggered manually as a GitHub Action that is called "Release New Version".
 In a dropdown menu, you can select how much you want to increment the version.
 The parameters that are selectable are directly passed to a ``poetry version`` command, so to see how the version changes, best check poetry's documentation directly `here <https://python-poetry.org/docs/cli#version>`_.
-
-.. note::
-  It is important to note, that all releases will be published on GitHub, but only stable releases (i.e., not prereleases -> there is no letter in the version number) will be released on pypi.
-  That ensures that users of the package can rely on PyPi to always have a up-to-date stable version, whereas developers can easily get pre-releases to test new functionality.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,6 @@ The following figure provides an overview of the workflow to generate networks u
    :maxdepth: 1
    :caption: Contents:
 
-   about
    section_introduction
    installation
    api/index

--- a/docs/section_examples.rst
+++ b/docs/section_examples.rst
@@ -11,8 +11,6 @@ This is a example gallery that is supposed to show different implementations of 
    examples/example_caveman_graph
    examples/example_cycle
    examples/example_fully_connected_graph
-   examples/example_grid
-   examples/example_line
    examples/example_lollipop
    examples/example_opinion_cluster
    examples/example_smallworld

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,7 +34,7 @@ bibliography: paper.bib
 
 Agent-based modeling (ABM) is a scientific method used in fields such as social science, biology, and ecology to simulate interactions of autonomous agents and study the resulting emergent phenomena.
 The relationships between agents, which structure the simulated interactions, are often represented by network graphs.
-Since empirical data on networks is rare, most agent-based models rely on artificially generated networks [@amblard_which_2015].
+Since empirical data on networks is rare, many agent-based models rely on artificially generated networks [@amblard_which_2015].
 Consequently, generating a valid network structure at the beginning of a simulation is critical.
 Addtionally, accessing and modifying the network during the simulation are steps that must be managed in almost any agent-based model.
 


### PR DESCRIPTION
This PR addresses some concerns of the reviewers during the publication process.

- I have extended the section to include a "How to contribute" tutorial.
- Fixed some warnings and errors in the documentation build process due to misaligned headings and non-existing documents.
- 2 warnings still remain (not sure what to do about them):
    1. test_creator_with_frameworks.ipynb is not linked in any toctree
    2. run_sim_in_different_networks.ipynb is not linked in any toctree
